### PR TITLE
Replace defunct function call to default.strinsAsFactors() + NEWS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Internals
 * Use **testthat** 3rd edition (#20).
+* The package was removed from CRAN due to an internal call to a defunct function `default.stringsAsFactors()`; fixed (@RLumSK)
 
 # gamma 1.0.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Internals
 * Use **testthat** 3rd edition (#20).
-* The package was removed from CRAN due to an internal call to a defunct function `default.stringsAsFactors()`; fixed (@RLumSK)
+* The package was removed from CRAN due to an internal call to a defunct function `default.stringsAsFactors()`; fixed (#23, @RLumSK)
 
 # gamma 1.0.1
 

--- a/R/coerce.R
+++ b/R/coerce.R
@@ -12,7 +12,7 @@ as.matrix.GammaSpectrum <- function(x, ...) methods::as(x, "matrix")
 #' @export
 as.data.frame.GammaSpectrum <- function(x, row.names = NULL, optional = FALSE,
                                         make.names = TRUE, ...,
-                                        stringsAsFactors = default.stringsAsFactors()) {
+                                        stringsAsFactors = FALSE) {
   x <- as.data.frame(x = as.matrix(x), row.names = row.names,
                      optional = optional, make.names = make.names, ...,
                      stringsAsFactors = stringsAsFactors)
@@ -79,7 +79,7 @@ as.matrix.PeakPosition <- function(x, ...) methods::as(x, "matrix")
 #' @export
 as.data.frame.PeakPosition <- function(x, row.names = NULL, optional = FALSE,
                                         make.names = TRUE, ...,
-                                        stringsAsFactors = default.stringsAsFactors()) {
+                                        stringsAsFactors = FALSE) {
   x <- as.data.frame(x = as.matrix(x), row.names = row.names,
                      optional = optional, make.names = make.names, ...,
                      stringsAsFactors = stringsAsFactors)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The package is currently removed from CRAN due to an unfortunate call to a defunct R function, this PR addresses the problem by replacing 

`default.stringsAsFactors()` through
`stringsAsFactors = FALSE`


