### PR TITLE
Implement request from #22 for GammaSpectra-class objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 # gamma 1.0.5
 ## Bugfixes & changes
 * Add support for Kromek SPE files to `read()`(#28 by @RLumSK)
+* Add support for `GammaSpectra-class` objects for `energy_calibrate()`(issue: #22)
 
 ## Internals
 * Fix unicode character in plot axis labels.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 # gamma 1.0.5
 ## Bugfixes & changes
 * Add support for Kromek SPE files to `read()`(#28 by @RLumSK)
-* Add support for `GammaSpectra-class` objects for `energy_calibrate()`(issue: #22)
+* Add support for `GammaSpectra-class` objects for `energy_calibrate()`(issue: #22, PR #31 by @RLumSK)
 
 ## Internals
 * Fix unicode character in plot axis labels.

--- a/R/energy_calibrate.R
+++ b/R/energy_calibrate.R
@@ -61,6 +61,28 @@ setMethod(
   }
 )
 
+#' @export
+#' @rdname energy
+#' @aliases energy_calibrate,GammaSpectra,PeakPosition-method
+setMethod(
+  f = "energy_calibrate",
+  signature = signature(object = "GammaSpectra", lines = "PeakPosition"),
+  definition = function(object, lines, ...) {
+    # Get data
+    peaks <- as.data.frame(lines)
+    peaks$energy <- peaks$energy_expected
+
+    # Adjust spectrum for energy shift using the same set of peask for
+    # the entire set of gamma spectra
+    # Return a new gamma spectrum with adjusted energy
+    spc <- lapply(unlist(object), energy_calibrate, peaks)
+
+    ## make create GammaSpectra class
+    methods::as(spc, "GammaSpectra")
+
+  }
+)
+
 # Predicates ===================================================================
 #' @export
 #' @rdname energy

--- a/man/energy.Rd
+++ b/man/energy.Rd
@@ -9,6 +9,7 @@
 \alias{has_calibration}
 \alias{energy_calibrate,GammaSpectrum,list-method}
 \alias{energy_calibrate,GammaSpectrum,PeakPosition-method}
+\alias{energy_calibrate,GammaSpectra,PeakPosition-method}
 \alias{has_energy,GammaSpectrum-method}
 \alias{has_energy,GammaSpectra-method}
 \alias{has_calibration,GammaSpectrum-method}
@@ -24,6 +25,8 @@ has_calibration(object)
 \S4method{energy_calibrate}{GammaSpectrum,list}(object, lines, ...)
 
 \S4method{energy_calibrate}{GammaSpectrum,PeakPosition}(object, lines, ...)
+
+\S4method{energy_calibrate}{GammaSpectra,PeakPosition}(object, lines, ...)
 
 \S4method{has_energy}{GammaSpectrum}(object)
 

--- a/tests/testthat/test-calibrate.R
+++ b/tests/testthat/test-calibrate.R
@@ -58,6 +58,24 @@ test_that("Calibrate a GammaSpectrum object with a PeakPosition object", {
   expect_length(spectrum@energy, 0)
   expect_length(calib@energy, 1024)
 })
+test_that("Calibrate a GammaSpectra object with a PeakPosition object", {
+  spc_file <- system.file("extdata/LaBr.TKA", package = "gamma")
+  spectrum_1 <- spectrum_2 <- read(spc_file)
+  spectra <- methods::as(list(spectrum_1, spectrum_2), "GammaSpectra")
+
+  peaks <- .PeakPosition(
+    hash = spectrum_1@hash,
+    channel = c(76L, 459L, 816L),
+    energy_expected = c(NA_real_, NA_real_, NA_real_)
+  )
+
+  set_energy(peaks) <- c(238, 1461, 2614.5)
+  calib <- energy_calibrate(spectra, lines = peaks)
+
+  expect_s4_class(calib, "GammaSpectra")
+
+})
+
 test_that("the energy scale of a GammaSpectrum is set", {
   cnf_file <- system.file("extdata/LaBr.CNF", package = "gamma")
   cnf_spc <- read(cnf_file)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Implement functionality to energy calibrate the `GammaSpectra-class` object.

## Description
+ ad method in energy_calibrate()
+ up docu
+ ad tests
+ ad NEWS

## Related Issue
#22 

## Example

```r
  spc_file <- system.file("extdata/LaBr.TKA", package = "gamma")
  spectrum_1 <- spectrum_2 <- read(spc_file)
  spectra <- methods::as(list(spectrum_1, spectrum_2), "GammaSpectra")

  peaks <- gamma:::.PeakPosition(
    hash = spectrum_1@hash,
    channel = c(76L, 459L, 816L),
    energy_expected = c(NA_real_, NA_real_, NA_real_)
  )

  set_energy(peaks) <- c(238, 1461, 2614.5)
```

