### PR TITLE
Update to issue #22

### DIFF
--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -233,7 +233,8 @@ NULL
 #'  Regardless of the approach you choose, it is strongly recommended to check
 #'  the result before proceeding.
 #' @return
-#'  * `energy_calibrate()` returns a [GammaSpectrum-class] object.
+#'  * `energy_calibrate()` returns either a [GammaSpectrum-class] or a [GammaSpectra-class]
+#'  object depending on the input#
 #'  * `has_energy()` and `has_calibration()` return a [`logical`] vector.
 #' @example inst/examples/ex-energy.R
 #' @author N. Frerebeau

--- a/R/energy_calibrate.R
+++ b/R/energy_calibrate.R
@@ -63,7 +63,7 @@ setMethod(
 
 #' @export
 #' @rdname energy
-#' @aliases energy_calibrate,GammaSpectra,PeakPosition-method
+#' @aliases energy_calibrate,GammaSpectra,list-method
 setMethod(
   f = "energy_calibrate",
   signature = signature(object = "GammaSpectra", lines = "list"),

--- a/R/energy_calibrate.R
+++ b/R/energy_calibrate.R
@@ -66,6 +66,23 @@ setMethod(
 #' @aliases energy_calibrate,GammaSpectra,PeakPosition-method
 setMethod(
   f = "energy_calibrate",
+  signature = signature(object = "GammaSpectra", lines = "list"),
+  definition = function(object, lines, ...) {
+
+    ## just call the regular function
+    spc <- lapply(unlist(object), energy_calibrate, lines)
+
+    ## make create GammaSpectra class
+    methods::as(spc, "GammaSpectra")
+
+  }
+)
+
+#' @export
+#' @rdname energy
+#' @aliases energy_calibrate,GammaSpectra,PeakPosition-method
+setMethod(
+  f = "energy_calibrate",
   signature = signature(object = "GammaSpectra", lines = "PeakPosition"),
   definition = function(object, lines, ...) {
     # Get data

--- a/man/energy.Rd
+++ b/man/energy.Rd
@@ -9,6 +9,7 @@
 \alias{has_calibration}
 \alias{energy_calibrate,GammaSpectrum,list-method}
 \alias{energy_calibrate,GammaSpectrum,PeakPosition-method}
+\alias{energy_calibrate,GammaSpectra,list-method}
 \alias{energy_calibrate,GammaSpectra,PeakPosition-method}
 \alias{has_energy,GammaSpectrum-method}
 \alias{has_energy,GammaSpectra-method}
@@ -25,6 +26,8 @@ has_calibration(object)
 \S4method{energy_calibrate}{GammaSpectrum,list}(object, lines, ...)
 
 \S4method{energy_calibrate}{GammaSpectrum,PeakPosition}(object, lines, ...)
+
+\S4method{energy_calibrate}{GammaSpectra,list}(object, lines, ...)
 
 \S4method{energy_calibrate}{GammaSpectra,PeakPosition}(object, lines, ...)
 
@@ -48,7 +51,8 @@ observed peak position ("\code{channel}") and the corresponding expected
 }
 \value{
 \itemize{
-\item \code{energy_calibrate()} returns a \linkS4class{GammaSpectrum} object.
+\item \code{energy_calibrate()} returns either a \linkS4class{GammaSpectrum} or a \linkS4class{GammaSpectra}
+object depending on the input#
 \item \code{has_energy()} and \code{has_calibration()} return a \code{\link{logical}} vector.
 }
 }

--- a/tests/testthat/test-calibrate.R
+++ b/tests/testthat/test-calibrate.R
@@ -58,6 +58,22 @@ test_that("Calibrate a GammaSpectrum object with a PeakPosition object", {
   expect_length(spectrum@energy, 0)
   expect_length(calib@energy, 1024)
 })
+test_that("Calibrate a GammaSpectra object with a list object", {
+  spc_file <- system.file("extdata/LaBr.TKA", package = "gamma")
+  spectrum_1 <- spectrum_2 <- read(spc_file)
+  spectra <- methods::as(list(spectrum_1, spectrum_2), "GammaSpectra")
+
+  lines <- list(
+    channel = c(76, 459, 816),
+    energy = c(238, 1461, 2614.5)
+  )
+
+  calib <- energy_calibrate(spectra, lines = lines)
+
+  expect_s4_class(calib, "GammaSpectra")
+
+})
+
 test_that("Calibrate a GammaSpectra object with a PeakPosition object", {
   spc_file <- system.file("extdata/LaBr.TKA", package = "gamma")
   spectrum_1 <- spectrum_2 <- read(spc_file)


### PR DESCRIPTION
In my last PR #31 addressing #22 I was not thorough enough and so I had missed the possibility to enable a `list` object for the `lines` parameters. This is now corrected. No NEWS are needed since it does not change this entry. I also updated the documentation. 

## Description
+ ad energy calibration with list input
+ up manual
+ ad tests
+ up docu of AllGenerics.R

## 

```r
 spc_file <- system.file("extdata/LaBr.TKA", package = "gamma")
  spectrum_1 <- spectrum_2 <- read(spc_file)
  spectra <- methods::as(list(spectrum_1, spectrum_2), "GammaSpectra")

  lines <- list(
    channel = c(76, 459, 816),
    energy = c(238, 1461, 2614.5)
  )

  calib <- energy_calibrate(spectra, lines = lines)

```
