### PR TITLE
Add additional coercion methods for PeakPosition-class

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 S3method(as.data.frame,GammaSpectrum)
 S3method(as.data.frame,PeakPosition)
+S3method(as.list,PeakPosition)
 S3method(as.matrix,GammaSpectrum)
 S3method(as.matrix,PeakPosition)
 exportMethods("[")

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 ## Bugfixes & changes
 * Add support for Kromek SPE files to `read()`(#28 by @RLumSK)
 * Add support for `GammaSpectra-class` objects for `energy_calibrate()`(issue: #22, PR #31 by @RLumSK)
+* Add coercion method for `PeakPosition-class` to `list` (exported as `as.list()`) and from `list` to `PeakPosition-class`. This enables better plotting functionality if the peak positions for where provided manually as `list` and not via, e.g., `peak_find()` ( by @RLumSK).
 * Update vignette about the dose rate calibration curve determination to make it more 
 intelligible (#30 by @RLumSK). 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 ## Bugfixes & changes
 * Add support for Kromek SPE files to `read()`(#28 by @RLumSK)
 * Add support for `GammaSpectra-class` objects for `energy_calibrate()`(issue: #22, PR #31 by @RLumSK)
-* Add coercion method for `PeakPosition-class` to `list` (exported as `as.list()`) and from `list` to `PeakPosition-class`. This enables better plotting functionality if the peak positions for where provided manually as `list` and not via, e.g., `peak_find()` ( by @RLumSK).
+* Add coercion method for `PeakPosition-class` to `list` (exported as `as.list()`) and from `list` to `PeakPosition-class`. This enables better plotting functionality if the peak positions for where provided manually as `list` and not via, e.g., `peak_find()` (PR #37 by @RLumSK).
 * Update vignette about the dose rate calibration curve determination to make it more 
 intelligible (#30 by @RLumSK). 
 

--- a/R/coerce.R
+++ b/R/coerce.R
@@ -86,6 +86,21 @@ as.data.frame.PeakPosition <- function(x, row.names = NULL, optional = FALSE,
   x
 }
 
+#' @method as.list PeakPosition
+#' @export
+as.list.PeakPosition <- function(x, ...) {
+  x <- as.matrix(x)
+
+  ## we opt for the observed energy as to be taken,
+  ## the others are just provided
+  list(
+    channel = x[,"channel"],
+    energy = x[,"energy_observed"],
+    energy_observed = x[,"energy_observed"],
+    energy_expected = x[,"energy_expected"]
+  )
+}
+
 setAs(
   from = "PeakPosition",
   to = "matrix",
@@ -104,5 +119,32 @@ setAs(
     m <- as.matrix(from)
     m <- as.data.frame(m, stringsAsFactors = FALSE)
     m
+  }
+)
+setAs(
+  from = "PeakPosition",
+  to = "list",
+  def = function(from) {
+    as.list(from)
+  }
+)
+setAs(
+  from = "list",
+  to = "PeakPosition",
+  def = function(from) {
+
+    ## check list entry names; the must match our expectations
+    from <- from[1:2]
+    names(from) <-  tolower(names(from))
+    if (!all(names(from) %in% c("channel", "energy")))
+      stop("Coercion failed because of list-element name mismatch. Allowed are 'channel' and 'energy'!", call. = FALSE)
+
+    ## create peak position object
+    .PeakPosition(
+      hash = "<man_coercion_list2PeakPosition>",
+      channel = from$channel,
+      energy_observed = from$energy,
+      energy_expected = from$energy
+    )
   }
 )

--- a/R/plot.R
+++ b/R/plot.R
@@ -112,7 +112,7 @@ setMethod(
   signature = signature(x = "GammaSpectrum", y = "PeakPosition"),
   definition = function(x, y, split = FALSE, span = 25) {
     # Validation
-    if (x@hash != y@hash)
+    if (y@hash != "<man_coercion_list2PeakPosition>" && x@hash != y@hash)
       stop("`x` and `y` do not match.", call. = FALSE)
 
     # Get data

--- a/tests/testthat/test-coerce.R
+++ b/tests/testthat/test-coerce.R
@@ -20,3 +20,27 @@ test_that("GammaSpectra from list", {
   expect_length(spectra, 1)
   expect_equal(names(spectra), "LaBr")
 })
+# PeakPosition =================================================================
+test_that("PeakPosition to and from", {
+  LaBr_file <- system.file("extdata/LaBr.TKA", package = "gamma")
+  LaBr_spc <- read(LaBr_file)
+  pks <- peaks_find(LaBr_spc)
+
+  ## try coercion to data.frame and matrix
+  expect_type(as.matrix(pks), "double")
+  expect_type(as.data.frame(pks), "list")
+  t <- expect_type(as.list(pks), "list")
+  expect_length(t, 4)
+
+  ## try the back conversion from list
+  pks <- list(channel = c(10,20,30), energy = c(100,200,300))
+  expect_s4_class(as(pks, "PeakPosition"), "PeakPosition")
+
+  ## crash function for list to PeakPosition
+  pks <- list(chan = c(10,20,30), en = c(100,200,300))
+  expect_error(as(pks, "PeakPosition"), "Coercion failed because of list-element name mismatch")
+
+  ## it should work, however, with a longer list
+  pks <- list(channel = c(10,20,30), energy = c(100,200,300), test = "s")
+  expect_s4_class(as(pks, "PeakPosition"), "PeakPosition")
+})


### PR DESCRIPTION
When I was setting my energy calibration peaks manually, I wanted to plot them automatically with the `plot()` method, but then I figured that this is not allowed and possible only when the `peak_find()` generated the `PeakPosition-class`. I therefore suggest to add additional coercing methods that facilitate a more convenient workflow. 

## Description

### Commit text
+ ad as.list.PeakPosition()
+ ad methods PeakPosition to list and list to PeakPosition
+ up plot() to work with the manual conversion
+ ad tests
+ up NAMESPACE
+ up NEWS
+ ad additional tests for existing coercion methods

The coercing from `list()` to `PeakPosition-class` checks for correct `list()` element names as already detailed for the manual energy lines. Additional list elements are ignored.

*Note: The adjustment in `plot()` seems a little bit ugly, but without the manually coerced `list()` to `PeakPosition-class()` does not benefit from the plotting. I have not exported the `list()` to `PeakPosition-class` as generic.*

## Related Issue

No related issue. 

## Example
```r
LaBr_file <- system.file("extdata/LaBr.TKA", package = "gamma")
LaBr_spc <- read(LaBr_file)
pks <- peaks_find(LaBr_spc)

## coercion to list (loosely)
as.list(pks)
```
```
$channel
[1]  35 496

$energy
[1] NA NA

$energy_observed
[1] NA NA

$energy_expected
[1] NA NA
```

```r
  as(pks, "list")
```

```
$channel
[1]  35 496

$energy
[1] NA NA

$energy_observed
[1] NA NA

$energy_expected
[1] NA NA

```

```r
  ## coercion from list 
  lines <- list(channel = c(10,20,30), energy = c(100,200,300))
  as(lines, "PeakPosition")
```

```
> 3 peaks were detected.
```
