### PR TITLE
Enable numeric input for background in dose_fit()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 * Add support for `GammaSpectra-class` objects for `energy_calibrate()`(issue: #22, PR #31 by @RLumSK).
 * Fix a graphical issue where the peaks were peaks were set with `set_energy()` but did not show correctly when plotted using the standard plot method, e.g., `plot(cal, pks)` would show only observed but not expected energy lines in the secondary x-axis. Now the expected energy lines (if set) are show. (#29, PR #32 by @RLumSK).
 * Add coercion method for `PeakPosition-class` to `list` (exported as `as.list()`) and from `list` to `PeakPosition-class`. This enables better plotting functionality if the peak positions for where provided manually as `list` and not via, e.g., `peak_find()` (PR #37 by @RLumSK).
+* Extend `dose_predict()` to work with a `numeric` input for `background` as claimed in the documentary. This value can also be set to `c(0,0)` if no background
+subtraction is wanted (@RLumSK)
 * Update vignette about the dose rate calibration curve determination to make it more intelligible (#30 by @RLumSK). 
 
 # gamma 1.0.5

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 * Fix a graphical issue where the peaks were peaks were set with `set_energy()` but did not show correctly when plotted using the standard plot method, e.g., `plot(cal, pks)` would show only observed but not expected energy lines in the secondary x-axis. Now the expected energy lines (if set) are show. (#29, PR #32 by @RLumSK).
 * Add coercion method for `PeakPosition-class` to `list` (exported as `as.list()`) and from `list` to `PeakPosition-class`. This enables better plotting functionality if the peak positions for where provided manually as `list` and not via, e.g., `peak_find()` (PR #37 by @RLumSK).
 * Extend `dose_predict()` to work with a `numeric` input for `background` as claimed in the documentary. This value can also be set to `c(0,0)` if no background
-subtraction is wanted (@RLumSK)
+subtraction is wanted (PR #38 by @RLumSK)
 * Update vignette about the dose rate calibration curve determination to make it more intelligible (#30 by @RLumSK). 
 
 # gamma 1.0.5

--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -1,10 +1,10 @@
 # CLASSES DEFINITION AND INITIALIZATION
 
-# Class Union ==================================================================
+# Class Union  (LmOrNull) ======================================================
 setClassUnion("LmOrNull", c("lm", "NULL"))
 
 # GammaSpectrum ================================================================
-#' An S4 Class to Represent a Gamma Sectrum
+#' An S4 Class to Represent a Gamma Spectrum
 #'
 #' Represents a single spectrum of a gamma ray spectrometry measurement.
 #' @slot hash A [`character`] string giving the 32-byte MD5 hash of
@@ -88,6 +88,9 @@ setClassUnion("LmOrNull", c("lm", "NULL"))
     calibration = NULL
   )
 )
+
+# Class Union  (GammaSpectrumOrNumeric) ========================================
+setClassUnion("GammaSpectrumOrNumeric", c("GammaSpectrum", "numeric"))
 
 # GammaSpectra =================================================================
 #' An S4 Class to Represent a Collection of Gamma Sectra

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -389,9 +389,9 @@ setGeneric(
 #'
 #' \code{dose_predict} predicts in situ gamma dose rate.
 #' @param object A [GammaSpectra-class] or [CalibrationCurve-class] object.
-#' @param background A [GammaSpectrum-class] object of a length-two [`numeric`]
+#' @param background A [GammaSpectrum-class] object or a length-two [`numeric`]
 #'  vector giving the background noise integration value and error,
-#'  respectively.
+#'  respectively. If no background subtraction is wanted, you can set `background = c(0,0,)`
 #' @param doses A [`matrix`] or [`data.frame`] object with gamma dose values and uncertainties.
 #' The row names must match the names of the spectrum.
 #' @param range_Ni,range_NiEi A length-two [`numeric`] vector giving the energy

--- a/R/dose_fit.R
+++ b/R/dose_fit.R
@@ -7,7 +7,7 @@ NULL
 #' @aliases dose_fit,GammaSpectra,GammaSpectrum,matrix-method
 setMethod(
   f = "dose_fit",
-  signature = signature(object = "GammaSpectra", background = "GammaSpectrum",
+  signature = signature(object = "GammaSpectra", background = "GammaSpectrumOrNumeric",
                         doses = "matrix"),
   definition = function(object, background, doses, range_Ni, range_NiEi,
                         details = list(authors = "", date = Sys.time())) {
@@ -22,7 +22,7 @@ setMethod(
 #' @aliases dose_fit,GammaSpectra,data.frame-method
 setMethod(
   f = "dose_fit",
-  signature = signature(object = "GammaSpectra", background = "GammaSpectrum",
+  signature = signature(object = "GammaSpectra", background = "GammaSpectrumOrNumeric",
                         doses = "data.frame"),
   definition = function(object, background, doses, range_Ni, range_NiEi,
                         details = list(authors = "", date = Sys.time())) {
@@ -51,8 +51,12 @@ setMethod(
 )
 
 fit_york <- function(object, background, doses, range, energy = FALSE) {
-  # Signal integration
-  bkg <- signal_integrate(background, range = range, energy = energy)
+  # Signal integration if we have a GammaSpectrum-class for the background
+  if (inherits(background, "GammaSpectrum"))
+    bkg <- signal_integrate(background, range = range, energy = energy)
+  else
+    bkg <- background
+
   signals <- signal_integrate(object, background = bkg, range = range,
                               energy = energy, simplify = TRUE)
 

--- a/man/GammaSpectrum-class.Rd
+++ b/man/GammaSpectrum-class.Rd
@@ -4,7 +4,7 @@
 \name{GammaSpectrum-class}
 \alias{GammaSpectrum-class}
 \alias{.GammaSpectrum}
-\title{An S4 Class to Represent a Gamma Sectrum}
+\title{An S4 Class to Represent a Gamma Spectrum}
 \description{
 Represents a single spectrum of a gamma ray spectrometry measurement.
 }

--- a/man/doserate.Rd
+++ b/man/doserate.Rd
@@ -7,8 +7,9 @@
 \alias{dose_fit-method}
 \alias{dose_predict}
 \alias{dose_predict-method}
+\alias{dose_fit,GammaSpectra,GammaSpectrumOrNumeric,matrix-method}
 \alias{dose_fit,GammaSpectra,GammaSpectrum,matrix-method}
-\alias{dose_fit,GammaSpectra,GammaSpectrum,data.frame-method}
+\alias{dose_fit,GammaSpectra,GammaSpectrumOrNumeric,data.frame-method}
 \alias{dose_fit,GammaSpectra,data.frame-method}
 \alias{dose_predict,CalibrationCurve,missing-method}
 \alias{dose_predict,CalibrationCurve,GammaSpectrum-method}
@@ -19,7 +20,7 @@ dose_fit(object, background, doses, ...)
 
 dose_predict(object, spectrum, ...)
 
-\S4method{dose_fit}{GammaSpectra,GammaSpectrum,matrix}(
+\S4method{dose_fit}{GammaSpectra,GammaSpectrumOrNumeric,matrix}(
   object,
   background,
   doses,
@@ -28,7 +29,7 @@ dose_predict(object, spectrum, ...)
   details = list(authors = "", date = Sys.time())
 )
 
-\S4method{dose_fit}{GammaSpectra,GammaSpectrum,data.frame}(
+\S4method{dose_fit}{GammaSpectra,GammaSpectrumOrNumeric,data.frame}(
   object,
   background,
   doses,
@@ -46,9 +47,9 @@ dose_predict(object, spectrum, ...)
 \arguments{
 \item{object}{A \linkS4class{GammaSpectra} or \linkS4class{CalibrationCurve} object.}
 
-\item{background}{A \linkS4class{GammaSpectrum} object of a length-two \code{\link{numeric}}
+\item{background}{A \linkS4class{GammaSpectrum} object or a length-two \code{\link{numeric}}
 vector giving the background noise integration value and error,
-respectively.}
+respectively. If no background subtraction is wanted, you can set \code{background = c(0,0,)}}
 
 \item{doses}{A \code{\link{matrix}} or \code{\link{data.frame}} object with gamma dose values and uncertainties.
 The row names must match the names of the spectrum.}


### PR DESCRIPTION
The manual for `dose_fit()` indicated (with a typo though) that `numeric` input of length 2 is possible as background. However, this was never implemented. I think that this is a meaningful feature because it allows to set the background value to any wanted value including 0 for no background. `signal_integrate()` was already ready to work with `numeric` as input, so I think it got just forgotten.  

I had to add a new class union because I did not want to set the signature to `"ANY"`, which appeared to be too bold for just a small feature. 

## Description
<!--- Describe your changes in detail -->
+ ad new class union GammaSpectrumOrNumeric
+ ad feature in dose_fit() and fit_york()
+ up docu in AllGenerics.R
+ up docu (roxygen2 run)
+ ad tests
+ ad NEWS
+ fx minor typos in code

## Related Issue
Not applicable.

## Example
```r
library(gamma)
data("clermont")

spc_dir <- system.file("extdata/BDX_LaBr_1/calibration", package = "gamma")
spc <- read(spc_dir)
bkg_numeric <- c(0,0)

calib_zero <- dose_fit(spc, bkg_numeric, doses,  range_Ni = c(300, 2800),
                    range_NiEi = c(165, 2800))
```
