### PR TITLE
Fix dose_predict() error calculation error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,11 @@
 # gamma 1.0.5.9000
 ## Bugfixes & changes
 * Fix an error in the uncertainty calculation of `dose_predict`. The returned error was too large and did not make 
-much sense due to an internal calculation error. Along with the fix, the manual was updated to details the 
-uncertainty calculation. (by @RLumSK)
+much sense due to an internal calculation error. Along with the fix, the manual was updated to detail the 
+uncertainty calculation. (PR #42 by @RLumSK)
+* Fix a graphical issue where the peaks were peaks were set with `set_energy()` but did not show correctly when plotted using the standard plot method, e.g., `plot(cal, pks)` would show only observed but not expected energy lines in the secondary x-axis. Now the expected energy lines (if set) are show. (#29, PR #32 by @RLumSK).
 * Add support for Kromek SPE files to `read()`(#28 by @RLumSK).
 * Add support for `GammaSpectra-class` objects for `energy_calibrate()`(issue: #22, PR #31 by @RLumSK).
-* Fix a graphical issue where the peaks were peaks were set with `set_energy()` but did not show correctly when plotted using the standard plot method, e.g., `plot(cal, pks)` would show only observed but not expected energy lines in the secondary x-axis. Now the expected energy lines (if set) are show. (#29, PR #32 by @RLumSK).
 * Add coercion method for `PeakPosition-class` to `list` (exported as `as.list()`) and from `list` to `PeakPosition-class`. This enables better plotting functionality if the peak positions for where provided manually as `list` and not via, e.g., `peak_find()` (PR #37 by @RLumSK).
 * Extend `dose_predict()` to work with a `numeric` input for `background` as claimed in the documentary. This value can also be set to `c(0,0)` if no background
 subtraction is wanted (PR #38 by @RLumSK)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # gamma 1.0.5.9000
 ## Bugfixes & changes
+* Fix an error in the uncertainty calculation of `dose_predict`. The returned error was too large and did not make 
+much sense due to an internal calculation error. Along with the fix, the manual was updated to details the 
+uncertainty calculation. (by @RLumSK)
 * Add support for Kromek SPE files to `read()`(#28 by @RLumSK).
 * Add support for `GammaSpectra-class` objects for `energy_calibrate()`(issue: #22, PR #31 by @RLumSK).
 * Fix a graphical issue where the peaks were peaks were set with `set_energy()` but did not show correctly when plotted using the standard plot method, e.g., `plot(cal, pks)` would show only observed but not expected energy lines in the secondary x-axis. Now the expected energy lines (if set) are show. (#29, PR #32 by @RLumSK).

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -401,9 +401,11 @@ setGeneric(
 #' @param spectrum An optional [GammaSpectrum-class] or [GammaSpectra-class]
 #'  object in which to look for variables with which to predict. If omitted,
 #'  the fitted values are used.
-#' @param sigma A [`numeric`] value giving TODO.
-#' @param epsilon A [`numeric`] value giving an extra error term
-#'  introduced by the calibration of the energy scale of the spectrum.
+#' @param sigma A [`numeric`] value giving the confidence level of which the error from the
+#' slope is considered in the final uncertainty calculation
+#' @param epsilon A [`numeric`] value giving an extra relative error term,
+#'  introduced by the calibration of the energy scale of the spectrum,
+#'  e.g., `0.015` for an additional 1.5% error
 #' @param ... Currently not used.
 #' @details
 #'  To estimate the gamma dose rate, one of the calibration curves distributed
@@ -418,6 +420,20 @@ setGeneric(
 #'  normalized to active time and corrected for background noise. The dose rate
 #'  is finally modelled by the integrated signal value used as a linear
 #'  predictor (York *et al.*, 2004).
+#'
+#'  **Uncertainty calculation of the gamma-dose rate**
+#'
+#'  The analytical uncertainties of the final gamma-dose rate (\eqn{SE(\dot{D}_{\gamma})}) are calculated as
+#'  follows:
+#'
+#'  \deqn{
+#'  SE(\dot{D_\gamma}) = \sqrt((\frac{m_{\delta}s}{m})^2 + (\frac{s_{\delta}}{s})^2 + \epsilon^2)
+#'  }
+#'
+#'  with \eqn{m} and \eqn{m_{\delta}} being the slope of the fit an its uncertainty,
+#'  \eqn{\sigma} the error scaler for the slope uncertainty, \eqn{s} and \eqn{s_{\delta}}
+#'  the integrated signal and its uncertainty, and \eqn{\epsilon} an additional relative uncertainty
+#'  term that can be set by the user using the argument `epsilon`.
 #'
 #'  See `vignette(doserate)` for a reproducible example.
 #' @return

--- a/R/dose_predict.R
+++ b/R/dose_predict.R
@@ -8,7 +8,7 @@ NULL
 setMethod(
   f = "dose_predict",
   signature = signature(object = "CalibrationCurve", spectrum = "missing"),
-  definition = function(object, sigma = 1, epsilon = 1.5) {
+  definition = function(object, sigma = 1, epsilon = 0.015) {
 
     Ni <- predict_york(object[["Ni"]],
                        energy = FALSE, sigma = sigma, epsilon = epsilon)
@@ -26,7 +26,7 @@ setMethod(
 setMethod(
   f = "dose_predict",
   signature = signature(object = "CalibrationCurve", spectrum = "GammaSpectrum"),
-  definition = function(object, spectrum, sigma = 1, epsilon = 1.5) {
+  definition = function(object, spectrum, sigma = 1, epsilon = 0.015) {
     spectrum <- methods::as(spectrum, "GammaSpectra")
     dose_predict(object, spectrum, sigma = sigma, epsilon = epsilon)
   }
@@ -38,7 +38,7 @@ setMethod(
 setMethod(
   f = "dose_predict",
   signature = signature(object = "CalibrationCurve", spectrum = "GammaSpectra"),
-  definition = function(object, spectrum, sigma = 1, epsilon = 1.5) {
+  definition = function(object, spectrum, sigma = 1, epsilon = 0.015) {
 
     Ni <- predict_york(object[["Ni"]], spectrum,
                        energy = FALSE, sigma = sigma, epsilon = epsilon)
@@ -81,9 +81,10 @@ predict_york <- function(model, spectrum, energy = FALSE,
   gamma_dose <- slope[[1L]] * signals$value + intercept[[1L]]
 
   gamma_error <- gamma_dose *
-    sqrt((slope[[2L]] * sigma / slope[[1L]])^2 +
-           (signals$error / signals$value)^2 +
-           epsilon^2)
+    sqrt(
+      ((slope[[2L]] * sigma) / slope[[1L]])^2 +
+      (signals$error / signals$value)^2 +
+      epsilon^2)
 
   results <- data.frame(
     names = signals$names,

--- a/man/doserate.Rd
+++ b/man/doserate.Rd
@@ -38,11 +38,11 @@ dose_predict(object, spectrum, ...)
   details = list(authors = "", date = Sys.time())
 )
 
-\S4method{dose_predict}{CalibrationCurve,missing}(object, sigma = 1, epsilon = 1.5)
+\S4method{dose_predict}{CalibrationCurve,missing}(object, sigma = 1, epsilon = 0.015)
 
-\S4method{dose_predict}{CalibrationCurve,GammaSpectrum}(object, spectrum, sigma = 1, epsilon = 1.5)
+\S4method{dose_predict}{CalibrationCurve,GammaSpectrum}(object, spectrum, sigma = 1, epsilon = 0.015)
 
-\S4method{dose_predict}{CalibrationCurve,GammaSpectra}(object, spectrum, sigma = 1, epsilon = 1.5)
+\S4method{dose_predict}{CalibrationCurve,GammaSpectra}(object, spectrum, sigma = 1, epsilon = 0.015)
 }
 \arguments{
 \item{object}{A \linkS4class{GammaSpectra} or \linkS4class{CalibrationCurve} object.}
@@ -66,10 +66,12 @@ range to integrate within (in keV).}
 \item{details}{A \code{\link{list}} of length-one vector specifying additional
 informations about the instrument for which the curve is built.}
 
-\item{sigma}{A \code{\link{numeric}} value giving TODO.}
+\item{sigma}{A \code{\link{numeric}} value giving the confidence level of which the error from the
+slope is considered in the final uncertainty calculation}
 
-\item{epsilon}{A \code{\link{numeric}} value giving an extra error term
-introduced by the calibration of the energy scale of the spectrum.}
+\item{epsilon}{A \code{\link{numeric}} value giving an extra relative error term,
+introduced by the calibration of the energy scale of the spectrum,
+e.g., \code{0.015} for an additional 1.5\% error}
 }
 \value{
 \itemize{
@@ -104,6 +106,20 @@ First, each reference spectrum is integrated over a given interval, then
 normalized to active time and corrected for background noise. The dose rate
 is finally modelled by the integrated signal value used as a linear
 predictor (York \emph{et al.}, 2004).
+
+\strong{Uncertainty calculation of the gamma-dose rate}
+
+The analytical uncertainties of the final gamma-dose rate (\eqn{SE(\dot{D}_{\gamma})}) are calculated as
+follows:
+
+\deqn{
+ SE(\dot{D_\gamma}) = \sqrt((\frac{m_{\delta}s}{m})^2 + (\frac{s_{\delta}}{s})^2 + \epsilon^2)
+ }
+
+with \eqn{m} and \eqn{m_{\delta}} being the slope of the fit an its uncertainty,
+\eqn{\sigma} the error scaler for the slope uncertainty, \eqn{s} and \eqn{s_{\delta}}
+the integrated signal and its uncertainty, and \eqn{\epsilon} an additional relative uncertainty
+term that can be set by the user using the argument \code{epsilon}.
 
 See \code{vignette(doserate)} for a reproducible example.
 }

--- a/tests/testthat/test-doserate.R
+++ b/tests/testthat/test-doserate.R
@@ -57,6 +57,9 @@ test_that("Estimate dose rates", {
   dose_rate4 <- dose_predict(calib_zeroBG, spc)
   expect_type(dose_rate4, "list")
 
+  ## regression test
+  expect_equal(sum(dose_rate2[,-1]), expected = 4005, tolerance = 1)
+
 })
 test_that("Get residuals", {
   data("BDX_LaBr_1")


### PR DESCRIPTION
The error calculation using `dose_predict()` was not correct because epsilon went
into the formula as `epsilon^2`. The preset was 1.5 and the documentation as not clear
about. It should have been `0.015`, otherwise the error becomes roughly the same as the estimated dose, which does not make much sense.

## Description
+ fx error calculation
+ ad more documentation
+ up manual
+ ad NEWS
+ ad additional regression test for calculation
+ ad additional warning if the spectra for the prediction come without energy calibration. This prevents systematic user errors

## Related Issue
Not applicable. 

## Examples

### Old
```r
rates <- dose_predict(AIX_NaI, test, sigma = 2)
rates
#>        names   dose_Ni error_Ni dose_NiEi error_NiEi
#> 1 NAR19-P2-1  925.2131 1388.917  898.0336   1348.102
#> 2 NAR19-P3-1 1116.4969 1676.068 1089.8538   1636.056
#> 3 NAR19-P4-1  894.0082 1342.074  869.4770   1305.233
#> 4 NAR19-P5-1 1391.7762 2089.312 1369.9492   2056.527
#> 5 NAR19-P6-1 1171.7514 1759.018 1152.1000   1729.499
```

### New

```r
rates <- dose_predict(AIX_NaI, test, sigma = 2)
rates
#>        names   dose_Ni error_Ni dose_NiEi error_NiEi
#> 1 NAR19-P2-1  925.2131 56.91231  898.0336   54.90534
#> 2 NAR19-P3-1 1116.4969 68.63574 1089.8538   66.63305
#> 3 NAR19-P4-1  894.0082 55.02411  869.4770   53.15946
#> 4 NAR19-P5-1 1391.7762 85.55814 1369.9492   83.75792
#> 5 NAR19-P6-1 1171.7514 72.11483 1152.1000   70.43890
```