### PR TITLE
Update documentation and output of the predict_dose()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,9 +7,11 @@ uncertainty calculation. (PR #42 by @RLumSK)
 * Add support for Kromek SPE files to `read()`(#28 by @RLumSK).
 * Add support for `GammaSpectra-class` objects for `energy_calibrate()`(issue: #22, PR #31 by @RLumSK).
 * Add coercion method for `PeakPosition-class` to `list` (exported as `as.list()`) and from `list` to `PeakPosition-class`. This enables better plotting functionality if the peak positions for where provided manually as `list` and not via, e.g., `peak_find()` (PR #37 by @RLumSK).
+* Add additional columns to the output object of `dose_predict()` and calculate a "final" dose based on the mean of the findings from the count and the energy threshold (by @RLumSK) 
 * Extend `dose_predict()` to work with a `numeric` input for `background` as claimed in the documentary. This value can also be set to `c(0,0)` if no background
 subtraction is wanted (PR #38 by @RLumSK)
 * Update vignette about the dose rate calibration curve determination to make it more intelligible (#30 by @RLumSK). 
+* Update manual for the output object of `dose_predict()`, which had some loopholes (by @RLumSK) 
 * Add conversion factor reference to `clermont` dataset for better transparency.
 * Add new dataset called `clermont_2024` based on the original `clermont` dataset but with dose rate conversion factors and gamma dose rate calculated for different conversion factor datasets (PR #40 by @RLumSK)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,11 +7,11 @@ uncertainty calculation. (PR #42 by @RLumSK)
 * Add support for Kromek SPE files to `read()`(#28 by @RLumSK).
 * Add support for `GammaSpectra-class` objects for `energy_calibrate()`(issue: #22, PR #31 by @RLumSK).
 * Add coercion method for `PeakPosition-class` to `list` (exported as `as.list()`) and from `list` to `PeakPosition-class`. This enables better plotting functionality if the peak positions for where provided manually as `list` and not via, e.g., `peak_find()` (PR #37 by @RLumSK).
-* Add additional columns to the output object of `dose_predict()` and calculate a "final" dose based on the mean of the findings from the count and the energy threshold (by @RLumSK) 
+* Add additional columns to the output object of `dose_predict()` and calculate a "final" dose based on the mean of the findings from the count and the energy threshold (PR #43 by @RLumSK) 
 * Extend `dose_predict()` to work with a `numeric` input for `background` as claimed in the documentary. This value can also be set to `c(0,0)` if no background
 subtraction is wanted (PR #38 by @RLumSK)
 * Update vignette about the dose rate calibration curve determination to make it more intelligible (#30 by @RLumSK). 
-* Update manual for the output object of `dose_predict()`, which had some loopholes (by @RLumSK) 
+* Update manual for the output object of `dose_predict()`, which had some loopholes (PR #43 by @RLumSK) 
 * Add conversion factor reference to `clermont` dataset for better transparency.
 * Add new dataset called `clermont_2024` based on the original `clermont` dataset but with dose rate conversion factors and gamma dose rate calculated for different conversion factor datasets (PR #40 by @RLumSK)
 

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -495,7 +495,7 @@ setGeneric(
 #' @param background A [GammaSpectrum-class] object.
 #' @param range A length-two [`numeric`] vector giving the energy range to
 #'  integrate within (in keV).
-#' @param energy A [`logical`] scalar: user the energy or count threshold?
+#' @param energy A [`logical`] scalar: use the energy or count threshold for the signal integration
 #' @param simplify A [`logical`] scalar: should the result be simplified to a
 #'  [`matrix`]? The default value, `FALSE`, returns a [`list`].
 #' @param ... Currently not used.

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -441,12 +441,20 @@ setGeneric(
 #'  * `dose_predict()` returns a [`data.frame`] with the following columns:
 #'  \describe{
 #'   \item{`name`}{([`character`]) the name of the spectra.}
-#'   \item{`*_signal`}{([`numeric`]) the integrated signal value (according to
+#'   \item{`signal_Ni`}{([`numeric`]) the integrated signal value (according to
+#'   the value of `threshold`; see [signal_integrate()]) for `energy = FALSE`}
+#'   \item{`signal_err_Ni`}{([`numeric`]) the integrated signal error value
+#'   (according to the value of `threshold`; see [signal_integrate()]) for `energy = FALSE`.}
+#'   \item{`dose_Ni`}{([`numeric`]) the predicted gamma dose rate for `energy = FALSE`.}
+#'   \item{`dose_err_Ni`}{([`numeric`]) the predicted gamma dose rate error for `energy = FALSE`.}
+#'   \item{`signal_Ni`}{([`numeric`]) the integrated signal value (according to
 #'   the value of `threshold`; see [signal_integrate()]).}
-#'   \item{`*_error`}{([`numeric`]) the integrated signal error value
-#'   (according to the value of `threshold`; see [signal_integrate()]).}
-#'   \item{`gamma_signal`}{([`numeric`]) the predicted gamma dose rate.}
-#'   \item{`gamma_error`}{([`numeric`]) the predicted gamma dose rate error.}
+#'   \item{`signal_err_NiEi`}{([`numeric`]) the integrated signal error value
+#'   (according to the value of `threshold`; see [signal_integrate()]) for `energy = TRUE`.}
+#'   \item{`dose_NiEi`}{([`numeric`]) the predicted gamma dose rate for `energy = TRUE`.}
+#'   \item{`dose_err_NiEi`}{([`numeric`]) the predicted gamma dose rate error for `energy = TRUE`.}
+#'   \item{`dose_final`}{([`numeric`]) the predicted final gamma dose rate as the mean of `dose_Ni` and `dose_NiEi`}
+#'   \item{`dose_err_final`}{([`numeric`]) the predicted final gamma dose rate error as the mean of `dose_err_Ni` and `dose_err_NiEi`.}
 #'  }
 #' @seealso [signal_integrate()]
 #' @references
@@ -487,7 +495,7 @@ setGeneric(
 #' @param background A [GammaSpectrum-class] object.
 #' @param range A length-two [`numeric`] vector giving the energy range to
 #'  integrate within (in keV).
-#' @param energy A [`logical`] scalar: TODO?
+#' @param energy A [`logical`] scalar: user the energy or count threshold?
 #' @param simplify A [`logical`] scalar: should the result be simplified to a
 #'  [`matrix`]? The default value, `FALSE`, returns a [`list`].
 #' @param ... Currently not used.

--- a/R/dose_predict.R
+++ b/R/dose_predict.R
@@ -10,13 +10,21 @@ setMethod(
   signature = signature(object = "CalibrationCurve", spectrum = "missing"),
   definition = function(object, sigma = 1, epsilon = 0.015) {
 
+    ## calculate for count threshold
     Ni <- predict_york(object[["Ni"]],
                        energy = FALSE, sigma = sigma, epsilon = epsilon)
 
+    ## calculate for energy threshold
     NiEi <- predict_york(object[["NiEi"]],
                          energy = TRUE, sigma = sigma, epsilon = epsilon)
 
-    merge(Ni, NiEi, by = "names", sort = FALSE, suffixes = c("_Ni","_NiEi"))
+    ## calculate the mean of both values
+    FINAL <- data.frame(
+      dose_final = rowMeans(matrix(c(Ni$dose, NiEi$dose), ncol = 2)),
+      dose_err_final = rowMeans(matrix(c(Ni$dose_err, NiEi$dose_err), ncol = 2)))
+
+    Ni_NiEi <- merge(Ni, NiEi, by = "names", sort = FALSE, suffixes = c("_Ni","_NiEi"))
+    cbind(Ni_NiEi, FINAL)
   }
 )
 
@@ -40,13 +48,22 @@ setMethod(
   signature = signature(object = "CalibrationCurve", spectrum = "GammaSpectra"),
   definition = function(object, spectrum, sigma = 1, epsilon = 0.015) {
 
+    ## calculate for count threshold
     Ni <- predict_york(object[["Ni"]], spectrum,
                        energy = FALSE, sigma = sigma, epsilon = epsilon)
 
+    ## calculate for energy threshold
     NiEi <- predict_york(object[["NiEi"]], spectrum,
                          energy = TRUE, sigma = sigma, epsilon = epsilon)
 
-    merge(Ni, NiEi, by = "names", sort = FALSE, suffixes = c("_Ni","_NiEi"))
+    ## calculate the mean of both values
+    FINAL <- data.frame(
+      dose_final = rowMeans(matrix(c(Ni$dose, NiEi$dose), ncol = 2)),
+      dose_err_final = rowMeans(matrix(c(Ni$dose_err, NiEi$dose_err), ncol = 2)))
+
+    Ni_NiEi <- merge(Ni, NiEi, by = "names", sort = FALSE, suffixes = c("_Ni","_NiEi"))
+    cbind(Ni_NiEi, FINAL)
+
   }
 )
 
@@ -88,8 +105,10 @@ predict_york <- function(model, spectrum, energy = FALSE,
 
   results <- data.frame(
     names = signals$names,
+    signal = signals$value,
+    signal_err = signals$error,
     dose = gamma_dose,
-    error = gamma_error,
+    dose_err = gamma_error,
     stringsAsFactors = FALSE
   )
   return(results)

--- a/man/doserate.Rd
+++ b/man/doserate.Rd
@@ -79,12 +79,20 @@ e.g., \code{0.015} for an additional 1.5\% error}
 \item \code{dose_predict()} returns a \code{\link{data.frame}} with the following columns:
 \describe{
 \item{\code{name}}{(\code{\link{character}}) the name of the spectra.}
-\item{\verb{*_signal}}{(\code{\link{numeric}}) the integrated signal value (according to
+\item{\code{signal_Ni}}{(\code{\link{numeric}}) the integrated signal value (according to
+the value of \code{threshold}; see \code{\link[=signal_integrate]{signal_integrate()}}) for \code{energy = FALSE}}
+\item{\code{signal_err_Ni}}{(\code{\link{numeric}}) the integrated signal error value
+(according to the value of \code{threshold}; see \code{\link[=signal_integrate]{signal_integrate()}}) for \code{energy = FALSE}.}
+\item{\code{dose_Ni}}{(\code{\link{numeric}}) the predicted gamma dose rate for \code{energy = FALSE}.}
+\item{\code{dose_err_Ni}}{(\code{\link{numeric}}) the predicted gamma dose rate error for \code{energy = FALSE}.}
+\item{\code{signal_Ni}}{(\code{\link{numeric}}) the integrated signal value (according to
 the value of \code{threshold}; see \code{\link[=signal_integrate]{signal_integrate()}}).}
-\item{\verb{*_error}}{(\code{\link{numeric}}) the integrated signal error value
-(according to the value of \code{threshold}; see \code{\link[=signal_integrate]{signal_integrate()}}).}
-\item{\code{gamma_signal}}{(\code{\link{numeric}}) the predicted gamma dose rate.}
-\item{\code{gamma_error}}{(\code{\link{numeric}}) the predicted gamma dose rate error.}
+\item{\code{signal_err_NiEi}}{(\code{\link{numeric}}) the integrated signal error value
+(according to the value of \code{threshold}; see \code{\link[=signal_integrate]{signal_integrate()}}) for \code{energy = TRUE}.}
+\item{\code{dose_NiEi}}{(\code{\link{numeric}}) the predicted gamma dose rate for \code{energy = TRUE}.}
+\item{\code{dose_err_NiEi}}{(\code{\link{numeric}}) the predicted gamma dose rate error for \code{energy = TRUE}.}
+\item{\code{dose_final}}{(\code{\link{numeric}}) the predicted final gamma dose rate as the mean of \code{dose_Ni} and \code{dose_NiEi}}
+\item{\code{dose_err_final}}{(\code{\link{numeric}}) the predicted final gamma dose rate error as the mean of \code{dose_err_Ni} and \code{dose_err_NiEi}.}
 }
 }
 }

--- a/man/integrate.Rd
+++ b/man/integrate.Rd
@@ -48,7 +48,7 @@ signal_integrate(object, background, ...)
 \item{range}{A length-two \code{\link{numeric}} vector giving the energy range to
 integrate within (in keV).}
 
-\item{energy}{A \code{\link{logical}} scalar: TODO?}
+\item{energy}{A \code{\link{logical}} scalar: user the energy or count threshold?}
 
 \item{simplify}{A \code{\link{logical}} scalar: should the result be simplified to a
 \code{\link{matrix}}? The default value, \code{FALSE}, returns a \code{\link{list}}.}

--- a/man/integrate.Rd
+++ b/man/integrate.Rd
@@ -48,7 +48,7 @@ signal_integrate(object, background, ...)
 \item{range}{A length-two \code{\link{numeric}} vector giving the energy range to
 integrate within (in keV).}
 
-\item{energy}{A \code{\link{logical}} scalar: user the energy or count threshold?}
+\item{energy}{A \code{\link{logical}} scalar: use the energy or count threshold for the signal integration}
 
 \item{simplify}{A \code{\link{logical}} scalar: should the result be simplified to a
 \code{\link{matrix}}? The default value, \code{FALSE}, returns a \code{\link{list}}.}

--- a/tests/testthat/test-doserate.R
+++ b/tests/testthat/test-doserate.R
@@ -44,21 +44,21 @@ test_that("Estimate dose rates", {
   # Missing
   dose_rate1 <- dose_predict(calib)
   expect_type(dose_rate1, "list")
-  expect_equal(dim(dose_rate1), c(7, 5))
+  expect_equal(dim(dose_rate1), c(7, 11))
   # GammaSpectrum
   dose_rate2 <- dose_predict(calib, spc[[1]])
   expect_type(dose_rate2, "list")
-  expect_equal(dim(dose_rate2), c(1, 5))
+  expect_equal(dim(dose_rate2), c(1, 11))
   # GammaSpectra
   dose_rate3 <- dose_predict(calib, spc)
   expect_type(dose_rate3, "list")
-  expect_equal(dim(dose_rate3), c(7, 5))
+  expect_equal(dim(dose_rate3), c(7, 11))
   # Background is numeric
   dose_rate4 <- dose_predict(calib_zeroBG, spc)
   expect_type(dose_rate4, "list")
 
   ## regression test
-  expect_equal(sum(dose_rate2[,-1]), expected = 4005, tolerance = 1)
+  expect_equal(sum(dose_rate2[,-1]), expected = 70105, tolerance = 1)
 
 })
 test_that("Get residuals", {


### PR DESCRIPTION
* The documentation did not correctly describe the data frame returned by `predict_dose()`. For instance, it was written that we can find the integrated signal in the output object, however, this was never returned. Those columns are now added and the documentation is aligned with output object.
* I've added a final dose estimate based on the mean of the two values as it was calculated in the old Excel sheet. This is a little bit clumsy (as it was in the past) but on the other hand people like simple values and this values are not entirely unjustified. 

**Warning: I had to rename the columns, this may (or not) break the shiny app.**   

## Description
+ ad new columns to the output of `dose_predict()` and align current columns with the previous expectation from the manual
+ ad final dose estimation based on mean to the `predict_dose()` output (as it was the case in the original Excel sheet)
+ up names of the columns
+ up manual
+ up NEWS
+ up tests
+ up documentation using roxygen2

## Related Issue
Not applicable

## Example

Output based on the vignette!

### Old output
```r
rates <- dose_predict(AIX_NaI, test, sigma = 2)
rates
#>        names   dose_Ni error_Ni dose_NiEi error_NiEi
#> 1 NAR19-P2-1  925.2131 56.91231  898.0336   54.90534
#> 2 NAR19-P3-1 1116.4969 68.63574 1089.8538   66.63305
#> 3 NAR19-P4-1  894.0082 55.02411  869.4770   53.15946
#> 4 NAR19-P5-1 1391.7762 85.55814 1369.9492   83.75792
#> 5 NAR19-P6-1 1171.7514 72.11483 1152.1000   70.43890
```

### New output
```r
rates <- dose_predict(AIX_NaI, test, sigma = 2)
rates
#>        names signal_Ni signal_err_Ni   dose_Ni dose_err_Ni signal_NiEi
#> 1 NAR19-P2-1  96.84460     0.3623222  925.2131    56.91231    50148.73
#> 2 NAR19-P3-1 117.77185     0.3585096 1116.4969    68.63574    61203.78
#> 3 NAR19-P4-1  93.43065     0.3997429  894.0082    55.02411    48502.94
#> 4 NAR19-P5-1 147.88856     0.4498253 1391.7762    85.55814    77346.35
#> 5 NAR19-P6-1 123.81692     0.5240536 1171.7514    72.11483    64791.18
#>   signal_err_NiEi dose_NiEi dose_err_NiEi dose_final dose_err_final
#> 1        8.281816  898.0336      54.90534   911.6234       55.90882
#> 2        8.203765 1089.8538      66.63305  1103.1754       67.63439
#> 3        9.148442  869.4770      53.15946   881.7426       54.09179
#> 4       10.316578 1369.9492      83.75792  1380.8627       84.65803
#> 5       12.026192 1152.1000      70.43890  1161.9257       71.27686
```