### PR TITLE
Minor fix error calculation dose_predict()

### DIFF
--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -454,7 +454,9 @@ setGeneric(
 #'   \item{`dose_NiEi`}{([`numeric`]) the predicted gamma dose rate for `energy = TRUE`.}
 #'   \item{`dose_err_NiEi`}{([`numeric`]) the predicted gamma dose rate error for `energy = TRUE`.}
 #'   \item{`dose_final`}{([`numeric`]) the predicted final gamma dose rate as the mean of `dose_Ni` and `dose_NiEi`}
-#'   \item{`dose_err_final`}{([`numeric`]) the predicted final gamma dose rate error as the mean of `dose_err_Ni` and `dose_err_NiEi`.}
+#'   \item{`dose_err_final`}{([`numeric`]) the predicted final gamma dose rate error as
+#'    \eqn{SE(\dot{D}_{\gamma}) = \sqrt{(\frac{SE(\dot{D}_{\gamma\mathrm{Ni}})}{\dot{D}_{\gamma\mathrm{Ni}}})^2 +
+#'    (\frac{SE(\dot{D}_{\gamma\mathrm{NiEi}})}{\dot{D}_{\gamma\mathrm{NiEi}}})^2}}}
 #'  }
 #' @seealso [signal_integrate()]
 #' @references

--- a/R/dose_predict.R
+++ b/R/dose_predict.R
@@ -18,10 +18,11 @@ setMethod(
     NiEi <- predict_york(object[["NiEi"]],
                          energy = TRUE, sigma = sigma, epsilon = epsilon)
 
-    ## calculate the mean of both values
-    FINAL <- data.frame(
-      dose_final = rowMeans(matrix(c(Ni$dose, NiEi$dose), ncol = 2)),
-      dose_err_final = rowMeans(matrix(c(Ni$dose_err, NiEi$dose_err), ncol = 2)))
+    ## calculate the mean and error of both values
+    dose_final <- rowMeans(matrix(c(Ni$dose, NiEi$dose), ncol = 2))
+    dose_err_final <- dose_final *
+      sqrt((Ni$dose_err/Ni$dose)^2 + (NiEi$dose_err/NiEi$dose)^2)
+    FINAL <- data.frame(dose_final, dose_err_final)
 
     Ni_NiEi <- merge(Ni, NiEi, by = "names", sort = FALSE, suffixes = c("_Ni","_NiEi"))
     cbind(Ni_NiEi, FINAL)
@@ -56,10 +57,11 @@ setMethod(
     NiEi <- predict_york(object[["NiEi"]], spectrum,
                          energy = TRUE, sigma = sigma, epsilon = epsilon)
 
-    ## calculate the mean of both values
-    FINAL <- data.frame(
-      dose_final = rowMeans(matrix(c(Ni$dose, NiEi$dose), ncol = 2)),
-      dose_err_final = rowMeans(matrix(c(Ni$dose_err, NiEi$dose_err), ncol = 2)))
+    ## calculate the mean and error of both values
+    dose_final <- rowMeans(matrix(c(Ni$dose, NiEi$dose), ncol = 2))
+    dose_err_final <- dose_final *
+      sqrt((Ni$dose_err/Ni$dose)^2 + (NiEi$dose_err/NiEi$dose)^2)
+    FINAL <- data.frame(dose_final, dose_err_final)
 
     Ni_NiEi <- merge(Ni, NiEi, by = "names", sort = FALSE, suffixes = c("_Ni","_NiEi"))
     cbind(Ni_NiEi, FINAL)

--- a/man/doserate.Rd
+++ b/man/doserate.Rd
@@ -92,7 +92,9 @@ the value of \code{threshold}; see \code{\link[=signal_integrate]{signal_integra
 \item{\code{dose_NiEi}}{(\code{\link{numeric}}) the predicted gamma dose rate for \code{energy = TRUE}.}
 \item{\code{dose_err_NiEi}}{(\code{\link{numeric}}) the predicted gamma dose rate error for \code{energy = TRUE}.}
 \item{\code{dose_final}}{(\code{\link{numeric}}) the predicted final gamma dose rate as the mean of \code{dose_Ni} and \code{dose_NiEi}}
-\item{\code{dose_err_final}}{(\code{\link{numeric}}) the predicted final gamma dose rate error as the mean of \code{dose_err_Ni} and \code{dose_err_NiEi}.}
+\item{\code{dose_err_final}}{(\code{\link{numeric}}) the predicted final gamma dose rate error as
+\eqn{SE(\dot{D}_{\gamma}) = \sqrt{(\frac{SE(\dot{D}_{\gamma\mathrm{Ni}})}{\dot{D}_{\gamma\mathrm{Ni}}})^2 +
+   (\frac{SE(\dot{D}_{\gamma\mathrm{NiEi}})}{\dot{D}_{\gamma\mathrm{NiEi}}})^2}}}
 }
 }
 }


### PR DESCRIPTION
Sorry, while having lunch it occurred to me that averaging the errors, even it was done in the Excel sheet, does not make much of a sense. I've corrected it and wrote in the manual how it is done. No further news, it corrects just my previous PR

## Description
+ up calculation to make mathematically more sense (errors are now not averaged)
+ up documentation for more transparency

## Related Issue
PR #43 

