### PR TITLE
Add water content correction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ uncertainty calculation. (PR #42 by @RLumSK)
 * Add coercion method for `PeakPosition-class` to `list` (exported as `as.list()`) and from `list` to `PeakPosition-class`. This enables better plotting functionality if the peak positions for where provided manually as `list` and not via, e.g., `peak_find()` (PR #37 by @RLumSK).
 * Add additional columns to the output object of `dose_predict()` and calculate a "final" dose based on the mean of the findings from the count and the energy threshold (PR #43 by @RLumSK) 
 * Add new argument `use_MC` to `dose_predic()` method. The default is `FALSE` to maintain compatibility with old code and output exceptions. If set to `TRUE` the uncertainty on the gamma dose rate uses a Monte Carlo simulation approach for a more realistic error estimation (PR #46 by RLumSK)
+* Add new function parameter `water_content` to `dose_predict()` to allow for an estimate of the dry gamma dose rate using the correction factor by Aitken (1985). The default is `NULL`, in this case nothing is corrected (PR #XX by @RLumSK)
 * Extend `dose_predict()` to work with a `numeric` input for `background` as claimed in the documentary. This value can also be set to `c(0,0)` if no background
 subtraction is wanted (PR #38 by @RLumSK)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@ uncertainty calculation. (PR #42 by @RLumSK)
 * Add coercion method for `PeakPosition-class` to `list` (exported as `as.list()`) and from `list` to `PeakPosition-class`. This enables better plotting functionality if the peak positions for where provided manually as `list` and not via, e.g., `peak_find()` (PR #37 by @RLumSK).
 * Add additional columns to the output object of `dose_predict()` and calculate a "final" dose based on the mean of the findings from the count and the energy threshold (PR #43 by @RLumSK) 
 * Add new argument `use_MC` to `dose_predict()` method. The default is `FALSE` to maintain compatibility with old code and output exceptions. If set to `TRUE` the uncertainty on the gamma dose rate uses a Monte Carlo simulation approach for a more realistic error estimation (PR #46 by RLumSK)
-* Add new function parameter `water_content` to `dose_predict()` to allow for an estimate of the dry gamma dose rate using the correction factor by Aitken (1985). The default is `NULL`, in this case nothing is corrected (PR #XX by @RLumSK)
+* Add new function parameter `water_content` to `dose_predict()` to allow for an estimate of the dry gamma dose rate using the correction factor by Aitken (1985). The default is `NULL`, in this case nothing is corrected (PR #48 by @RLumSK)
 * Extend `dose_predict()` to work with a `numeric` input for `background` as claimed in the documentary. This value can also be set to `c(0,0)` if no background
 subtraction is wanted (PR #38 by @RLumSK)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # gamma 1.0.5.9000
 ## Bugfixes
-* Fix an error in the uncertainty calculation of `dose_predict`. The returned error was too large and did not make 
+* Fix an error in the uncertainty calculation of `dose_predict()`. The returned error was too large and did not make 
 much sense due to an internal calculation error. Along with the fix, the manual was updated to detail the 
 uncertainty calculation. (PR #42 by @RLumSK)
 * Fix a graphical issue where the peaks were peaks were set with `set_energy()` but did not show correctly when plotted using the standard plot method, e.g., `plot(cal, pks)` would show only observed but not expected energy lines in the secondary x-axis. Now the expected energy lines (if set) are show. (#29, PR #32 by @RLumSK).
@@ -11,7 +11,7 @@ uncertainty calculation. (PR #42 by @RLumSK)
 * Add support for `GammaSpectra-class` objects for `energy_calibrate()`(issue: #22, PR #31 by @RLumSK).
 * Add coercion method for `PeakPosition-class` to `list` (exported as `as.list()`) and from `list` to `PeakPosition-class`. This enables better plotting functionality if the peak positions for where provided manually as `list` and not via, e.g., `peak_find()` (PR #37 by @RLumSK).
 * Add additional columns to the output object of `dose_predict()` and calculate a "final" dose based on the mean of the findings from the count and the energy threshold (PR #43 by @RLumSK) 
-* Add new argument `use_MC` to `dose_predic()` method. The default is `FALSE` to maintain compatibility with old code and output exceptions. If set to `TRUE` the uncertainty on the gamma dose rate uses a Monte Carlo simulation approach for a more realistic error estimation (PR #46 by RLumSK)
+* Add new argument `use_MC` to `dose_predict()` method. The default is `FALSE` to maintain compatibility with old code and output exceptions. If set to `TRUE` the uncertainty on the gamma dose rate uses a Monte Carlo simulation approach for a more realistic error estimation (PR #46 by RLumSK)
 * Add new function parameter `water_content` to `dose_predict()` to allow for an estimate of the dry gamma dose rate using the correction factor by Aitken (1985). The default is `NULL`, in this case nothing is corrected (PR #XX by @RLumSK)
 * Extend `dose_predict()` to work with a `numeric` input for `background` as claimed in the documentary. This value can also be set to `c(0,0)` if no background
 subtraction is wanted (PR #38 by @RLumSK)

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -406,6 +406,10 @@ setGeneric(
 #' @param epsilon A [`numeric`] value giving an extra relative error term,
 #'  introduced by the calibration of the energy scale of the spectrum,
 #'  e.g., `0.015` for an additional 1.5% error
+#' @param water_content [`numeric`] or [`matrix`] gravimetric field water content to correct
+#' the gamma-dose rate to using the correction factor by Aitken (1985) to obtain the dry gamma-dose
+#' rate. Example: `c(0.05,0.0001)` for water content of 5% +/- 0.01 %. The default is `NULL` (nothing is corrected).
+#' The correction only works on the final dose rate. For more information see details.
 #' @param use_MC A [`logical`] parameter, enabling/disabling Monte Carlo simulations for estimating
 #' the dose rate uncertainty
 #' @param ... Currently not used.
@@ -449,9 +453,24 @@ setGeneric(
 #'
 #'  \eqn{\ rho} is the parameter `sigma` provided with the function call, \eqn{SD} equals the
 #'  the call to `sd()`, i.e. the calculation of the standard deviation. To achieve a good
-#'  gaussian normal approximation with sample 1+e06 times (the values is fixed).
+#'  Gaussian normal approximation with sample 1+e06 times (the values is fixed).
 #'
-#'  See `vignette(doserate)` for a reproducible example.
+#'  **Water content correction**
+#'
+#' If gamma-dose rates are measured in the field, they are measured at  "as-is" conditions.
+#' In dating studies, however, using the dry dose rate is often more desirable to model the
+#' long-term effect of different assumptions for the water content. If the parameter `water_content`,
+#' either as [numeric] vector or as [matrix] with the number of rows equal to the
+#' number of processed spectra,  if different values are desired, the **final** gamma-dose rate is
+#' corrected for the water content provided. Final uncertainties are obtained using the square
+#' root of the summed squared relative uncertainties of the dose rate and the water content.
+#'
+#' A word of caution: When estimating the water content in the laboratory, the water
+#' analytical uncertainty is usually minimal, and it does not make sense to
+#' correct with a relative water content of, e.g., c(0.02,0.02) (2% +/- 2%) because
+#' this massively inflates the final dose rate error.
+#'
+#' See `vignette(doserate)` for a reproducible example.
 #' @return
 #'  * `dose_fit()` returns a [CalibrationCurve-class] object.
 #'  * `dose_predict()` returns a [`data.frame`] with the following columns:
@@ -476,6 +495,10 @@ setGeneric(
 #'  }
 #' @seealso [signal_integrate()]
 #' @references
+#'
+#'  Aitken, M.J. (1985). Thermoluminescence dating, Studies in archaeological science.
+#'  Academic Press, London.
+#'
 #'  Mercier, N. & Falguères, C. (2007). Field Gamma Dose-Rate Measurement with
 #'  a NaI(Tl) Detector: Re-Evaluation of the "Threshold" Technique.
 #'  *Ancient TL*, 25(1), p. 1-4.

--- a/man/doserate.Rd
+++ b/man/doserate.Rd
@@ -38,11 +38,31 @@ dose_predict(object, spectrum, ...)
   details = list(authors = "", date = Sys.time())
 )
 
-\S4method{dose_predict}{CalibrationCurve,missing}(object, sigma = 1, epsilon = 0.015, use_MC = FALSE)
+\S4method{dose_predict}{CalibrationCurve,missing}(
+  object,
+  sigma = 1,
+  epsilon = 0.015,
+  water_content = NULL,
+  use_MC = FALSE
+)
 
-\S4method{dose_predict}{CalibrationCurve,GammaSpectrum}(object, spectrum, sigma = 1, epsilon = 0.015, use_MC = FALSE)
+\S4method{dose_predict}{CalibrationCurve,GammaSpectrum}(
+  object,
+  spectrum,
+  sigma = 1,
+  epsilon = 0.015,
+  water_content = NULL,
+  use_MC = FALSE
+)
 
-\S4method{dose_predict}{CalibrationCurve,GammaSpectra}(object, spectrum, sigma = 1, epsilon = 0.015, use_MC = FALSE)
+\S4method{dose_predict}{CalibrationCurve,GammaSpectra}(
+  object,
+  spectrum,
+  sigma = 1,
+  epsilon = 0.015,
+  water_content = NULL,
+  use_MC = FALSE
+)
 }
 \arguments{
 \item{object}{A \linkS4class{GammaSpectra} or \linkS4class{CalibrationCurve} object.}
@@ -72,6 +92,11 @@ slope is considered in the final uncertainty calculation}
 \item{epsilon}{A \code{\link{numeric}} value giving an extra relative error term,
 introduced by the calibration of the energy scale of the spectrum,
 e.g., \code{0.015} for an additional 1.5\% error}
+
+\item{water_content}{\code{\link{numeric}} or \code{\link{matrix}} gravimetric field water content to correct
+the gamma-dose rate to using the correction factor by Aitken (1985) to obtain the dry gamma-dose
+rate. Example: \code{c(0.05,0.0001)} for water content of 5\% +/- 0.01 \%. The default is \code{NULL} (nothing is corrected).
+The correction only works on the final dose rate. For more information see details.}
 
 \item{use_MC}{A \code{\link{logical}} parameter, enabling/disabling Monte Carlo simulations for estimating
 the dose rate uncertainty}
@@ -146,7 +171,22 @@ is chosen to approximate the uncertainties on the dose rate:
 
 \eqn{\ rho} is the parameter \code{sigma} provided with the function call, \eqn{SD} equals the
 the call to \code{sd()}, i.e. the calculation of the standard deviation. To achieve a good
-gaussian normal approximation with sample 1+e06 times (the values is fixed).
+Gaussian normal approximation with sample 1+e06 times (the values is fixed).
+
+\strong{Water content correction}
+
+If gamma-dose rates are measured in the field, they are measured at  "as-is" conditions.
+In dating studies, however, using the dry dose rate is often more desirable to model the
+long-term effect of different assumptions for the water content. If the parameter \code{water_content},
+either as \link{numeric} vector or as \link{matrix} with the number of rows equal to the
+number of processed spectra,  if different values are desired, the \strong{final} gamma-dose rate is
+corrected for the water content provided. Final uncertainties are obtained using the square
+root of the summed squared relative uncertainties of the dose rate and the water content.
+
+A word of caution: When estimating the water content in the laboratory, the water
+analytical uncertainty is usually minimal, and it does not make sense to
+correct with a relative water content of, e.g., c(0.02,0.02) (2\% +/- 2\%) because
+this massively inflates the final dose rate error.
 
 See \code{vignette(doserate)} for a reproducible example.
 }
@@ -176,6 +216,9 @@ plot(calib_curve, threshold = "Ni")
 dose_predict(calib_curve, spc)
 }
 \references{
+Aitken, M.J. (1985). Thermoluminescence dating, Studies in archaeological science.
+Academic Press, London.
+
 Mercier, N. & Falguères, C. (2007). Field Gamma Dose-Rate Measurement with
 a NaI(Tl) Detector: Re-Evaluation of the "Threshold" Technique.
 \emph{Ancient TL}, 25(1), p. 1-4.

--- a/tests/testthat/test-doserate.R
+++ b/tests/testthat/test-doserate.R
@@ -1,6 +1,5 @@
-data("clermont")
-
 test_that("Build a calibration curve", {
+  data("clermont")
   spc_dir <- system.file("extdata/BDX_LaBr_1/calibration", package = "gamma")
   spc <- read(spc_dir)
   bkg_dir <- system.file("extdata/BDX_LaBr_1/background", package = "gamma")
@@ -34,7 +33,10 @@ test_that("Build a calibration curve", {
 })
 test_that("Estimate dose rates", {
   testthat::skip_on_cran()
+
+  data("clermont")
   set.seed(1234)
+
   spc_dir <- system.file("extdata/BDX_LaBr_1/calibration", package = "gamma")
   spc <- read(spc_dir)
   bkg_dir <- system.file("extdata/BDX_LaBr_1/background", package = "gamma")
@@ -68,6 +70,14 @@ test_that("Estimate dose rates", {
   dose_rate4 <- expect_silent(dose_predict(calib_zeroBG, spc))
   dose_rate4_MC <- expect_silent(dose_predict(calib_zeroBG, spc, use_MC = TRUE))
   expect_type(dose_rate4, "list")
+
+  ## check water content attribute
+  expect_type(dose_predict(calib, water_content = c(0.02,0.0001), use_MC = FALSE), "list")
+  water_content <- matrix(c(0.05,0.20,0,0), ncol = 2)
+  expect_warning(dose_predict(calib, water_content = water_content, use_MC = FALSE),
+                 regexp = "Number of rows in matrix 'water_content' unequal to number of spectra. Values recycled!")
+  water_content <- matrix(c(0.05,0.05,0.05,0.05,0.05,0.05,0.05,0,0,0,0,0,0,0), ncol = 2)
+  expect_type(dose_predict(calib, water_content = water_content, use_MC = FALSE), "list")
 
   ## regression test
   expect_equal(sum(dose_rate2[,-1]), expected = 70105, tolerance = 1)


### PR DESCRIPTION
For the age calculation we usually use the dry gamma-dose rate instead of the water affected dose rate measured in the field. I've added a new argument to address this issue and enable a straightforward correction of the gamma-dose rate for the water content (which is usually measured in the laboratory)

## Description

Add water_content parameter
+ ad parameter to dose_predict()
+ up manual
+ ad tests
+ ad NEWS
+ up manual

## Related Issue
Not applicable. 

## Example

```r
data("clermont")
spc_dir <- system.file("extdata/BDX_LaBr_1/calibration", package = "gamma")
spc <- read(spc_dir)
bkg_dir <- system.file("extdata/BDX_LaBr_1/background", package = "gamma")
bkg <- read(bkg_dir)
doses <- clermont[, c("gamma_dose", "gamma_error")]
calib <- dose_fit(spc, bkg, doses,  range_Ni = c(300, 2800),
                    range_NiEi = c(165, 2800))

dose_predict(calib, water_content = c(0.02,0.0001), use_MC = FALSE)
```